### PR TITLE
Change Money currency property to currency_code

### DIFF
--- a/lib/gogokit/money.rb
+++ b/lib/gogokit/money.rb
@@ -13,7 +13,7 @@ module GogoKit
     include Representable::JSON
 
     property :amount
-    property :currency
+    property :currency_code
     property :display
   end
 end


### PR DESCRIPTION
The currency_code field seems to be missing from GogoKit::Money objects, this change fixes the issue.

    > listings.items.first.ticket_price
    => #<GogoKit::Money amount=900.0, currency_code="DKK", display="DKK900">
    > listings.items.first.ticket_price.currency_code
    => "DKK"

I'm still having an issue with the display property, however:

    > listings.items.first.ticket_price.display
    #<GogoKit::Money amount=900.0, currency_code="DKK", display="DKK900">=> nil